### PR TITLE
Add Drupal 11 support to submodules

### DIFF
--- a/modules/yusaopeny_ymca360_instudio/yusaopeny_ymca360_instudio.info.yml
+++ b/modules/yusaopeny_ymca360_instudio/yusaopeny_ymca360_instudio.info.yml
@@ -2,6 +2,6 @@ name: 'YMCA360 Integration - Schedule Sync'
 type: module
 description: 'Integration with YMCA360 Platform - pulls in In-Person and InStudio schedules.'
 package: 'YMCA'
-core_version_requirement: ^8 || ^9 || ^10
+core_version_requirement: ^8 || ^9 || ^10 || ^11
 dependencies:
   - yusaopeny_ymca360:yusaopeny_ymca360

--- a/modules/yusaopeny_ymca360_livestreams/yusaopeny_ymca360_livestreams.info.yml
+++ b/modules/yusaopeny_ymca360_livestreams/yusaopeny_ymca360_livestreams.info.yml
@@ -4,6 +4,6 @@ description: 'Integration with YMCA360 Platform - pull Live Stream schedule'
 package: 'YMCA'
 lifecycle: deprecated
 lifecycle_link: 'https://ymca360.org/'
-core_version_requirement: ^8 || ^9 || ^10
+core_version_requirement: ^8 || ^9 || ^10 || ^11
 dependencies:
   - yusaopeny_ymca360:yusaopeny_ymca360


### PR DESCRIPTION
## Summary
- Add Drupal 11 support to yusaopeny_ymca360_instudio submodule
- Add Drupal 11 support to yusaopeny_ymca360_livestreams submodule

## Changes
Updated `core_version_requirement` in both submodules from `^8 || ^9 || ^10` to `^8 || ^9 || ^10 || ^11`.

## Files Changed
- modules/yusaopeny_ymca360_instudio/yusaopeny_ymca360_instudio.info.yml
- modules/yusaopeny_ymca360_livestreams/yusaopeny_ymca360_livestreams.info.yml

## Testing
- Verified compatibility with Drupal 11.1.9
- Tested module installation and functionality

## Compatibility
This change maintains backward compatibility with Drupal 8, 9, and 10 while adding support for Drupal 11.