### PR TITLE
fix: Drupal 11 ConfigFormBase compatibility

### DIFF
--- a/modules/yusaopeny_ymca360_livestreams/src/Form/SettingsForm.php
+++ b/modules/yusaopeny_ymca360_livestreams/src/Form/SettingsForm.php
@@ -3,6 +3,7 @@
 namespace Drupal\yusaopeny_ymca360_livestreams\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\State\StateInterface;
@@ -24,9 +25,9 @@ class SettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function __construct(ConfigFactoryInterface $config_factory, StateInterface $state) {
+  public function __construct(ConfigFactoryInterface $config_factory, TypedConfigManagerInterface $typed_config, StateInterface $state) {
     $this->state = $state;
-    parent::__construct($config_factory);
+    parent::__construct($config_factory, $typed_config);
   }
 
   /**

--- a/src/Form/LocationsMappingForm.php
+++ b/src/Form/LocationsMappingForm.php
@@ -3,6 +3,7 @@
 namespace Drupal\yusaopeny_ymca360\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -39,8 +40,8 @@ class LocationsMappingForm extends ConfigFormBase {
   /**
    * Constructs a \Drupal\system\ConfigFormBase object.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entityTypeManager, Y360Client $client, Y360MappingRepository $repository) {
-    parent::__construct($config_factory);
+  public function __construct(ConfigFactoryInterface $config_factory, TypedConfigManagerInterface $typed_config, EntityTypeManagerInterface $entityTypeManager, Y360Client $client, Y360MappingRepository $repository) {
+    parent::__construct($config_factory, $typed_config);
     $this->nodeStorage = $entityTypeManager->getStorage('node');
     $this->client = $client;
     $this->mappingRepository = $repository;
@@ -52,6 +53,7 @@ class LocationsMappingForm extends ConfigFormBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('config.factory'),
+      $container->get('config.typed'),
       $container->get('entity_type.manager'),
       $container->get('yusaopeny_ymca360.y360_client'),
       $container->get('yusaopeny_ymca360.mapping_repository')

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -3,6 +3,7 @@
 namespace Drupal\yusaopeny_ymca360\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -42,6 +43,7 @@ class SettingsForm extends ConfigFormBase {
    */
   public function __construct(
     ConfigFactoryInterface $config_factory,
+    TypedConfigManagerInterface $typed_config,
     StateInterface $state,
     ModuleHandlerInterface $module_handler,
     Y360Client $client
@@ -50,7 +52,7 @@ class SettingsForm extends ConfigFormBase {
     $this->state = $state;
     $this->module_handler = $module_handler;
     $this->client = $client;
-    parent::__construct($config_factory);
+    parent::__construct($config_factory, $typed_config);
   }
 
   /**
@@ -59,6 +61,7 @@ class SettingsForm extends ConfigFormBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('config.factory'),
+      $container->get('config.typed'),
       $container->get('state'),
       $container->get('module_handler'),
       $container->get('yusaopeny_ymca360.y360_client')
@@ -145,7 +148,7 @@ class SettingsForm extends ConfigFormBase {
         $form['schedule']['schedules'][$id]['enable'] = [
           '#type' => 'checkbox',
           '#title' => "$label ($id)",
-          '#default_value' => (bool) $schedule_mapping[$id]['enable'],
+          '#default_value' => (bool) ($schedule_mapping[$id]['enable'] ?? FALSE),
         ];
         $form['schedule']['schedules'][$id]['subcategory'] = [
           '#type' => 'entity_autocomplete',


### PR DESCRIPTION
## Summary
Fixes 500 error on YMCA360 settings page when running on Drupal 11.

## Problem
In Drupal 11, `ConfigFormBase::__construct()` requires `TypedConfigManagerInterface` as the second argument:

```php
public function __construct(
  ConfigFactoryInterface $config_factory,
  protected TypedConfigManagerInterface $typedConfigManager,
) {
  $this->setConfigFactory($config_factory);
}
```

The current forms only pass `ConfigFactoryInterface`, causing:
```
Too few arguments to function Drupal\Core\Form\ConfigFormBase::__construct(), 
1 passed... and exactly 2 expected
```

## Changes
Updates three form classes to include `TypedConfigManagerInterface`:
- `src/Form/SettingsForm.php`
- `src/Form/LocationsMappingForm.php`
- `modules/yusaopeny_ymca360_livestreams/src/Form/SettingsForm.php`

Also fixes PHP warning for undefined array key when schedule ID from YMCA360 API doesn't exist in saved config mapping.

## Testing
- Verified `/admin/config/system/yusaopeny-ymca360/settings` loads without 500 error on Drupal 11.1.8
- Verified settings can be saved

Fixes #2