### PR TITLE
chore: prep 2.0.0 release — drop manual version, add maintainers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,15 @@
     "name": "ycloudyusa/yusaopeny_ymca360",
     "description": "YUSA OpenY YMCA360 integration",
     "type": "drupal-module",
-    "version": "1.1.99-dev",
     "authors": [
+        {
+            "name": "Andrii Podanenko",
+            "email": "podarokua@gmail.com"
+        },
+        {
+            "name": "Vlad Sadretdinov",
+            "email": "vlad.sadretdinov@jet.dev"
+        },
         {
             "name": "Andrey Zbukar",
             "email": "andrey.zbukar@fivejars.com"


### PR DESCRIPTION
## Summary

Release prep for `2.0.0`.

- Drop manual `"version": "1.1.99-dev"` from `composer.json` so packagist resolves the package version from the git tag (Drupal contrib best practice). Without this, sites pinning `dev-2.x` against a tagged `2.0.0` would see the manual string as authoritative and Composer's resolver would misorder versions.
- Add `Andrii Podanenko` and `Vlad Sadretdinov` to `authors` (on top of the existing maintainers).

No code changes. Once merged, tag `2.0.0` from `2.x` HEAD and cut a GitHub release.

## Test plan

- [ ] `composer.json` validates: `composer validate --strict`
- [ ] On a consumer site with `"ycloudyusa/yusaopeny_ymca360": "^2.0"`, `composer update` after the `2.0.0` tag is published resolves to the tagged version.
