### PR TITLE
fix: #8 Ensure sessions with Content Moderation are published

### DIFF
--- a/src/syncer/LoaderBase.php
+++ b/src/syncer/LoaderBase.php
@@ -295,11 +295,22 @@ abstract class LoaderBase implements LoaderInterface {
 
   /**
    * Applies publish state to a session according to upstream data + config.
+   *
+   * When Content Moderation governs the session bundle, setPublished() alone
+   * is not enough — the moderation_state field controls the final revision
+   * status and must be set explicitly, otherwise nodes are always saved as
+   * 'draft' regardless of the published flag.
    */
   protected function applyPublishState(NodeInterface $session, array $item): void {
-    $session->setUnpublished();
-    if ($this->isPublishedSession($item)) {
+    $publish = $this->isPublishedSession($item);
+    if ($publish) {
       $session->setPublished();
+    }
+    else {
+      $session->setUnpublished();
+    }
+    if ($session->hasField('moderation_state')) {
+      $session->set('moderation_state', $publish ? 'published' : 'draft');
     }
   }
 


### PR DESCRIPTION
If sessions use Content Moderation, we need to ensure they get the proper moderation state. 

To test:
- enable Content Moderation for Session content type
- try the syncer
- see that sessions are posted as draft and not published