### PR TITLE
Keep in-progress occurrences in sync window (ITCP-651)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The submodule's install hook adds `yusaopeny_ymca360_instudio.syncer` to `ymca_s
 | Hook | Purpose |
 |---|---|
 | `yusaopeny_ymca360_instudio_update_10001` | Backfills the new sync settings (`window_days`, `page_size`, `max_deletes_per_run`, `canceled_title_prefix`, `canceled_publish_behavior`) when missing. |
+| `yusaopeny_ymca360_instudio_update_10003` | Backfills `sync.window_offset_days = 1` so already-started occurrences stay in the window. |
 | `yusaopeny_ymca360_instudio_update_10002` | Removes the syncer-owned bundles (`session`, `activity`, `class`, `program`, `program_subcategory`) from `trash.settings.enabled_entity_types.node` if Trash is enabled and tracks nodes. Other bundles the site has opted into Trash for are preserved. |
 
 </details>
@@ -88,7 +89,8 @@ The submodule's install hook adds `yusaopeny_ymca360_instudio.syncer` to `ymca_s
 
 | Setting | Default | Notes |
 |---|---|---|
-| `window_days` | `14` | How many days ahead of `now` to pull. Items before `now` are never extracted, so reconciliation removes them on the next run. |
+| `window_days` | `14` | How many days ahead of `now` to pull. Combined with `window_offset_days`, the extracted window is `[now - window_offset_days, now + window_days]`. |
+| `window_offset_days` | `1` | How many days *before* `now` to include. Keeps occurrences that already started but have not yet ended (e.g. an Open Swim 5am–5pm at 11am) inside the window so reconciliation does not delete them as orphans. Set to `0` to revert to the pre-2.x behaviour where any occurrence with `start_at < now` is dropped immediately. Increase if you run multi-day occurrences. |
 | `page_size` | `500` | Items per API page. Larger pages = fewer requests but more memory per request. |
 | `max_deletes_per_run` | `500` | Hard cap on deletions per sync cycle. Excess is logged and deferred to subsequent runs. Set to `0` to disable. |
 | `empty_extract_threshold` | `2` | How many consecutive empty extracts must occur before reconciliation runs against an empty set. Lower it to `1` to disable the circuit breaker. |
@@ -120,7 +122,7 @@ flowchart LR
     E -.->|circuit breaker streak| KV[(keyvalue)]
 ```
 
-- **Extractor** builds the `[now, now + window_days]` window and calls `Y360Client::getSchedulesWindowed()` with the API's native filters. Pagination is API-driven. Tracks consecutive empty extracts in the `yusaopeny_ymca360_syncer` keyvalue collection and toggles `DataWrapper::skipOrphanReconciliation` until emptiness is confirmed.
+- **Extractor** builds the `[now - window_offset_days, now + window_days]` window and calls `Y360Client::getSchedulesWindowed()` with the API's native filters. Pagination is API-driven. Tracks consecutive empty extracts in the `yusaopeny_ymca360_syncer` keyvalue collection and toggles `DataWrapper::skipOrphanReconciliation` until emptiness is confirmed.
 - **Transformer** classifies the working set:
   - `status=deleted` → existing mapping queued for delete.
   - hash matches existing mapping → no-op (unchanged item).

--- a/modules/yusaopeny_ymca360_instudio/config/install/yusaopeny_ymca360_instudio.settings.yml
+++ b/modules/yusaopeny_ymca360_instudio/config/install/yusaopeny_ymca360_instudio.settings.yml
@@ -2,6 +2,7 @@ cron:
   enable_cron: 0
 sync:
   window_days: 14
+  window_offset_days: 1
   page_size: 500
   max_deletes_per_run: 500
   canceled_title_prefix: 'CANCELED: '

--- a/modules/yusaopeny_ymca360_instudio/src/Form/SettingsForm.php
+++ b/modules/yusaopeny_ymca360_instudio/src/Form/SettingsForm.php
@@ -58,6 +58,15 @@ class SettingsForm extends ConfigFormBase {
       '#max' => 365,
       '#step' => 1,
     ];
+    $form['sync']['window_offset_days'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Past days (window offset)'),
+      '#description' => $this->t('How many days <em>before</em> today to include in the sync window. Keeps occurrences that already started but have not yet ended (e.g. an Open Swim 5am–5pm shown at 11am) from being reconciled away. Set to 0 to drop any occurrence the moment it starts. Increase if you run multi-day occurrences.'),
+      '#default_value' => $config->get('sync.window_offset_days') ?? 1,
+      '#min' => 0,
+      '#max' => 30,
+      '#step' => 1,
+    ];
     $form['sync']['page_size'] = [
       '#type' => 'number',
       '#title' => $this->t('API page size'),

--- a/modules/yusaopeny_ymca360_instudio/src/syncer/Extractor.php
+++ b/modules/yusaopeny_ymca360_instudio/src/syncer/Extractor.php
@@ -74,13 +74,19 @@ class Extractor extends ExtractorBase implements ExtractorInterface {
   /**
    * Resolves the current sync window from config.
    *
+   * The window starts `window_offset_days` before "now" so that occurrences
+   * which already started but have not yet ended (e.g. a 5am–5pm Open Swim at
+   * 11am) remain inside the window — otherwise the API's `scheduled_from`
+   * filter hides them and the reconciliation step deletes their mappings.
+   *
    * @return array{from: int, to: int}
    */
   protected function resolveSyncWindow($instudio): array {
     $windowDays = (int) ($instudio->get('sync.window_days') ?? 14);
+    $offsetDays = (int) ($instudio->get('sync.window_offset_days') ?? 1);
     $now = time();
     return [
-      'from' => $now,
+      'from' => $now - ($offsetDays * 86400),
       'to' => $now + ($windowDays * 86400),
     ];
   }

--- a/modules/yusaopeny_ymca360_instudio/yusaopeny_ymca360_instudio.install
+++ b/modules/yusaopeny_ymca360_instudio/yusaopeny_ymca360_instudio.install
@@ -117,3 +117,15 @@ function yusaopeny_ymca360_instudio_update_10001(): string {
   }
   return 'Added settings: ' . implode(', ', $added) . '.';
 }
+
+/**
+ * Add sync.window_offset_days so in-progress occurrences stay in the window.
+ */
+function yusaopeny_ymca360_instudio_update_10003(): string {
+  $config = \Drupal::configFactory()->getEditable('yusaopeny_ymca360_instudio.settings');
+  if ($config->get('sync.window_offset_days') !== NULL) {
+    return 'sync.window_offset_days already set — nothing to do.';
+  }
+  $config->set('sync.window_offset_days', 1)->save();
+  return 'Added sync.window_offset_days = 1.';
+}

--- a/src/Drush/Commands/Y360Commands.php
+++ b/src/Drush/Commands/Y360Commands.php
@@ -78,7 +78,8 @@ final class Y360Commands extends DrushCommands {
     $now = \Drupal::time()->getRequestTime();
     $instudio = \Drupal::config('yusaopeny_ymca360_instudio.settings');
     $windowDays = (int) ($instudio->get('sync.window_days') ?? 14);
-    $from = gmdate(DateTimeItemInterface::DATETIME_STORAGE_FORMAT, $now);
+    $offsetDays = (int) ($instudio->get('sync.window_offset_days') ?? 1);
+    $from = gmdate(DateTimeItemInterface::DATETIME_STORAGE_FORMAT, $now - $offsetDays * 86400);
     $to = gmdate(DateTimeItemInterface::DATETIME_STORAGE_FORMAT, $now + $windowDays * 86400);
 
     $total = (int) $this->database->query('SELECT COUNT(*) FROM {y360_mapping}')->fetchField();


### PR DESCRIPTION
## Problem

A site reported that occurrences disappear from `/schedules` the moment they start, even though they are still running:

- Open Swim 5am–5pm vanishes at 5am.
- Water Fitness 11:15–11:55am vanishes at 11:15am.
- Lap Swim 5am–12pm vanishes at 5am.

Members need to know an in-progress program is still going (or that the space is occupied) until it actually ends.

## Root cause

`Extractor::resolveSyncWindow()` sets `from = time()` and the `Y360Client` passes that as both `start_at` and `scheduled_from`. The `/schedules` API treats `scheduled_from` as "hide everything that started before this", so any occurrence with `start_at < now` is omitted. Reconciliation then sees no matching API item for the stored mapping and deletes it as an orphan — and the corresponding session node disappears from the schedule.

## Fix

Shift the window's `from` boundary back by `sync.window_offset_days` (default `1`):

```php
$offsetDays = (int) ($instudio->get('sync.window_offset_days') ?? 1);
'from' => $now - ($offsetDays * 86400),
```

With a 1-day offset the API still returns occurrences whose `start_at` is earlier today, so they stay inside the window, reconciliation keeps the mapping, and the schedule keeps showing the row until its actual end time.

The value is configurable so a site that runs longer-than-24h occurrences (overnight events, multi-day classes) can extend it without code changes.

## Changes

- `modules/yusaopeny_ymca360_instudio/src/syncer/Extractor.php` — apply offset in `resolveSyncWindow()`.
- `modules/yusaopeny_ymca360_instudio/config/install/yusaopeny_ymca360_instudio.settings.yml` — default `window_offset_days: 1`.
- `modules/yusaopeny_ymca360_instudio/yusaopeny_ymca360_instudio.install` — `update_10003` backfills the value on existing installs.
- `src/Drush/Commands/Y360Commands.php` — `y360:status` reports the same offset so the displayed window matches the real sync window.

## Test plan

- [x] `drush updb -y` runs `yusaopeny_ymca360_instudio_update_10003` and sets `sync.window_offset_days = 1` (idempotent on re-run).
- [x] `drush y360:status` shows `Window: <yesterday-now> → <now+window_days>`.
- [x] `drush y360:sync` completes; mappings for occurrences whose `start_at` is earlier today are retained instead of being reconciled away.
- [x] Counts: on a real site after the fix, in-window mappings increased by ~124 and past-orphan count dropped by the same amount — those are the rows that previously fell out of the window the moment they started.
- [x] Setting `sync.window_offset_days: 0` reproduces the previous behaviour (verified by config override).

Refs: ITCP-651