### PR TITLE
Add config schema

### DIFF
--- a/config/schema/yusaopeny_ymca360.schema.yml
+++ b/config/schema/yusaopeny_ymca360.schema.yml
@@ -1,0 +1,50 @@
+# Schema for the configuration files of the YMCA360 module.
+
+yusaopeny_ymca360.settings:
+  type: config_object
+  label: 'YMCA360 settings'
+  mapping:
+    api_url:
+      type: string
+      label: 'API URL'
+    credentials:
+      type: mapping
+      label: 'API credentials'
+      mapping:
+        user:
+          type: string
+          label: 'Username'
+        password:
+          type: string
+          label: 'Password'
+    schedule:
+      type: mapping
+      label: 'Schedule settings'
+      mapping:
+        schedules:
+          type: sequence
+          label: 'Schedules to sync'
+          sequence:
+            type: mapping
+            label: 'Schedule entry'
+            mapping:
+              enable:
+                type: boolean
+                label: 'Enable sync for this schedule'
+              subcategory:
+                type: integer
+                label: 'Local program subcategory node ID'
+    limit:
+      type: integer
+      label: 'Import limit (0 = no limit)'
+
+ymca_sync.settings:
+  type: config_object
+  label: 'YMCA Sync settings'
+  mapping:
+    active_syncers:
+      type: sequence
+      label: 'Active syncers'
+      sequence:
+        type: string
+        label: 'Syncer service ID'

--- a/modules/yusaopeny_ymca360_instudio/config/schema/yusaopeny_ymca360_instudio.schema.yml
+++ b/modules/yusaopeny_ymca360_instudio/config/schema/yusaopeny_ymca360_instudio.schema.yml
@@ -1,0 +1,38 @@
+# Schema for the configuration files of the YMCA360 InStudio submodule.
+
+yusaopeny_ymca360_instudio.settings:
+  type: config_object
+  label: 'YMCA360 InStudio settings'
+  mapping:
+    cron:
+      type: mapping
+      label: 'Automatic sync'
+      mapping:
+        enable_cron:
+          type: boolean
+          label: 'Enable sync on cron runs'
+    sync:
+      type: mapping
+      label: 'Sync window'
+      mapping:
+        window_days:
+          type: integer
+          label: 'Future days (window size)'
+        window_offset_days:
+          type: integer
+          label: 'Past days (window offset)'
+        page_size:
+          type: integer
+          label: 'API page size'
+        max_deletes_per_run:
+          type: integer
+          label: 'Max deletes per run'
+        empty_extract_threshold:
+          type: integer
+          label: 'Consecutive empty extract threshold before orphan reconciliation'
+        canceled_title_prefix:
+          type: string
+          label: 'Canceled session title prefix'
+        canceled_publish_behavior:
+          type: string
+          label: 'Canceled session publish behavior'

--- a/modules/yusaopeny_ymca360_livestreams/config/schema/yusaopeny_ymca360_livestreams.schema.yml
+++ b/modules/yusaopeny_ymca360_livestreams/config/schema/yusaopeny_ymca360_livestreams.schema.yml
@@ -1,0 +1,13 @@
+# Schema for the configuration files of the YMCA360 Livestreams submodule.
+
+yusaopeny_ymca360_livestreams.settings:
+  type: config_object
+  label: 'YMCA360 Livestreams settings'
+  mapping:
+    cron:
+      type: mapping
+      label: 'Automatic sync'
+      mapping:
+        enable_cron:
+          type: boolean
+          label: 'Enable sync on cron runs'


### PR DESCRIPTION
Adds [config schema](https://www.drupal.org/docs/drupal-apis/configuration-api/configuration-schemametadata).

We should probably have tests at some point too, but this is one step toward them.

Also inspired by https://www.drupal.org/project/yusaopeny_ymca360/issues/3581417#comment-16525093