### PR TITLE
Fix getSchedulesWindowed pagination: paginate by page exhaustion, not total_pages

### DIFF
--- a/modules/yusaopeny_ymca360_instudio/src/syncer/Extractor.php
+++ b/modules/yusaopeny_ymca360_instudio/src/syncer/Extractor.php
@@ -30,7 +30,7 @@ class Extractor extends ExtractorBase implements ExtractorInterface {
     $items = $result['items'] ?? [];
     $stats = $result['stats'] ?? [];
 
-    $this->logger->info('[EXTRACTOR] Window fetch: %pages pages, %total items returned by API.', [
+    $this->logger->info('[EXTRACTOR] Window fetch: %pages pages, %total items collected.', [
       '%pages' => $stats['pages_fetched'] ?? 0,
       '%total' => $stats['api_total'] ?? 0,
     ]);

--- a/src/Y360Client.php
+++ b/src/Y360Client.php
@@ -203,7 +203,7 @@ class Y360Client {
     $options = array_merge([
       'headers' => ['Accept' => 'application/json'],
       'auth' => $this->getAuth(),
-      'timeout' => 120,
+      'timeout' => 60,
     ], $options);
 
     $queryString = $this->buildQueryString($params);

--- a/src/Y360Client.php
+++ b/src/Y360Client.php
@@ -110,15 +110,17 @@ class Y360Client {
     $queryParams = $this->buildWindowedQuery($fromTimestamp, $toTimestamp, $pageSize);
 
     $items = [];
-    $totalPages = 1;
     $apiTotal = 0;
     $pagesFetched = 0;
 
+    // The YMCA360 API always returns total_pages=0 regardless of the true
+    // result set size, so we cannot rely on it. Instead we paginate until
+    // we receive a partial page (fewer items than requested), which signals
+    // the final page has been reached.
     do {
       $data = $this->doRequest($queryParams);
       $pagesFetched++;
       if ($queryParams['page'] === 0) {
-        $totalPages = $data['summary']['total_pages'] ?? 1;
         $apiTotal = $data['summary']['total_items'] ?? count($data['items'] ?? []);
       }
 
@@ -130,7 +132,7 @@ class Y360Client {
 
       $queryParams['page']++;
       usleep(100000);
-    } while ($queryParams['page'] < $totalPages);
+    } while (count($pageItems) >= $pageSize);
 
     return [
       'items' => $items,

--- a/src/Y360Client.php
+++ b/src/Y360Client.php
@@ -110,7 +110,6 @@ class Y360Client {
     $queryParams = $this->buildWindowedQuery($fromTimestamp, $toTimestamp, $pageSize);
 
     $items = [];
-    $apiTotal = 0;
     $pagesFetched = 0;
 
     // The YMCA360 API always returns total_pages=0 regardless of the true
@@ -120,9 +119,6 @@ class Y360Client {
     do {
       $data = $this->doRequest($queryParams);
       $pagesFetched++;
-      if ($queryParams['page'] === 0) {
-        $apiTotal = $data['summary']['total_items'] ?? count($data['items'] ?? []);
-      }
 
       $pageItems = $data['items'] ?? [];
       if (empty($pageItems)) {
@@ -138,7 +134,7 @@ class Y360Client {
       'items' => $items,
       'stats' => [
         'pages_fetched' => $pagesFetched,
-        'api_total' => $apiTotal,
+        'api_total' => count($items),
         'window_items' => count($items),
       ],
     ];

--- a/src/Y360Client.php
+++ b/src/Y360Client.php
@@ -203,7 +203,7 @@ class Y360Client {
     $options = array_merge([
       'headers' => ['Accept' => 'application/json'],
       'auth' => $this->getAuth(),
-      'timeout' => 60,
+      'timeout' => 120,
     ], $options);
 
     $queryString = $this->buildQueryString($params);


### PR DESCRIPTION
## Problem

Closes #13

`getSchedulesWindowed()` only ever fetched page 0 of results. The loop used `total_pages` from the API summary to decide when to stop:

```php
} while ($queryParams['page'] < $totalPages);
```

The YMCA360 API **always returns `total_pages: 0`** and clamps `total_items` to the current page size. After fetching page 0, the condition `1 < 0` is always false — the loop exits immediately, every time.

With a 14-day window and `page_size=500` this meant **~80–90% of future schedule data was silently dropped** on every sync run.

## Fix

Replace the `total_pages`-based termination with **page exhaustion**: keep fetching until the API returns fewer items than the requested page size (a partial page = final page).

```diff
-    $totalPages = 1;
     $apiTotal = 0;
     $pagesFetched = 0;

+    // The YMCA360 API always returns total_pages=0 regardless of the true
+    // result set size, so we cannot rely on it. Instead we paginate until
+    // we receive a partial page (fewer items than requested), which signals
+    // the final page has been reached.
     do {
       ...
-        $totalPages = $data['summary']['total_pages'] ?? 1;
       ...
-    } while ($queryParams['page'] < $totalPages);
+    } while (count($pageItems) >= $pageSize);
```

## Verified

Tested against the live API with a 14-day sync window:

| | pages fetched | items returned | last item date |
|---|---|---|---|
| Before | 1 | 500 | June 16 |
| After | 10 | 4,707 | June 29 ✓ |

The API does paginate correctly — each page returns unique, non-overlapping items advancing forward in time. Only the summary metadata (`total_pages`, `total_items`) is unreliable.