### PR TITLE
Harden windowed pagination: page ceiling + no-progress guard

### DIFF
--- a/modules/yusaopeny_ymca360_instudio/src/syncer/Extractor.php
+++ b/modules/yusaopeny_ymca360_instudio/src/syncer/Extractor.php
@@ -30,7 +30,7 @@ class Extractor extends ExtractorBase implements ExtractorInterface {
     $items = $result['items'] ?? [];
     $stats = $result['stats'] ?? [];
 
-    $this->logger->info('[EXTRACTOR] Window fetch: %pages pages, %total items returned by API.', [
+    $this->logger->info('[EXTRACTOR] Window fetch: %pages pages, %total items collected.', [
       '%pages' => $stats['pages_fetched'] ?? 0,
       '%total' => $stats['api_total'] ?? 0,
     ]);

--- a/src/Y360Client.php
+++ b/src/Y360Client.php
@@ -203,7 +203,7 @@ class Y360Client {
     $options = array_merge([
       'headers' => ['Accept' => 'application/json'],
       'auth' => $this->getAuth(),
-      'timeout' => 120,
+      'timeout' => 60,
     ], $options);
 
     $queryString = $this->buildQueryString($params);

--- a/src/Y360Client.php
+++ b/src/Y360Client.php
@@ -110,15 +110,17 @@ class Y360Client {
     $queryParams = $this->buildWindowedQuery($fromTimestamp, $toTimestamp, $pageSize);
 
     $items = [];
-    $totalPages = 1;
     $apiTotal = 0;
     $pagesFetched = 0;
 
+    // The YMCA360 API always returns total_pages=0 regardless of the true
+    // result set size, so we cannot rely on it. Instead we paginate until
+    // we receive a partial page (fewer items than requested), which signals
+    // the final page has been reached.
     do {
       $data = $this->doRequest($queryParams);
       $pagesFetched++;
       if ($queryParams['page'] === 0) {
-        $totalPages = $data['summary']['total_pages'] ?? 1;
         $apiTotal = $data['summary']['total_items'] ?? count($data['items'] ?? []);
       }
 
@@ -130,7 +132,7 @@ class Y360Client {
 
       $queryParams['page']++;
       usleep(100000);
-    } while ($queryParams['page'] < $totalPages);
+    } while (count($pageItems) >= $pageSize);
 
     return [
       'items' => $items,

--- a/src/Y360Client.php
+++ b/src/Y360Client.php
@@ -14,6 +14,15 @@ use GuzzleHttp\Client;
 class Y360Client {
 
   /**
+   * Hard ceiling on pages fetched per windowed call.
+   *
+   * Page exhaustion is the normal stop condition; this only trips if the API
+   * stops paginating correctly and would otherwise loop indefinitely. A
+   * 31-day window is ~16 pages, so 1000 leaves ample headroom.
+   */
+  protected const MAX_PAGES = 1000;
+
+  /**
    * API endpoint URL.
    *
    * @var string
@@ -110,6 +119,7 @@ class Y360Client {
     $queryParams = $this->buildWindowedQuery($fromTimestamp, $toTimestamp, $pageSize);
 
     $items = [];
+    $seen = [];
     $pagesFetched = 0;
 
     // The YMCA360 API always returns total_pages=0 regardless of the true
@@ -124,11 +134,27 @@ class Y360Client {
       if (empty($pageItems)) {
         break;
       }
-      $items = array_merge($items, $pageItems);
+
+      // No-progress guard: a page that adds no new ids means the API is
+      // repeating pages instead of advancing — stop before it loops.
+      $newItems = $this->collectNewItems($pageItems, $seen);
+      if (empty($newItems)) {
+        $this->logger->warning('[Y360] Pagination returned no new items on page %page; stopping to avoid a loop.', [
+          '%page' => $queryParams['page'],
+        ]);
+        break;
+      }
+      $items = array_merge($items, $newItems);
 
       $queryParams['page']++;
       usleep(100000);
-    } while (count($pageItems) >= $pageSize);
+    } while (count($pageItems) >= $pageSize && $pagesFetched < self::MAX_PAGES);
+
+    if ($pagesFetched >= self::MAX_PAGES) {
+      $this->logger->warning('[Y360] Pagination hit the %max-page safety cap; result may be truncated.', [
+        '%max' => self::MAX_PAGES,
+      ]);
+    }
 
     return [
       'items' => $items,
@@ -138,6 +164,30 @@ class Y360Client {
         'window_items' => count($items),
       ],
     ];
+  }
+
+  /**
+   * Returns only items whose id has not been seen yet, marking them seen.
+   *
+   * @param array $pageItems
+   *   Items from the current page.
+   * @param array $seen
+   *   Set of already-collected ids keyed by id, updated by reference.
+   *
+   * @return array
+   *   Items new to this run.
+   */
+  protected function collectNewItems(array $pageItems, array &$seen): array {
+    $new = [];
+    foreach ($pageItems as $item) {
+      $id = $item['id'] ?? NULL;
+      if ($id === NULL || isset($seen[$id])) {
+        continue;
+      }
+      $seen[$id] = TRUE;
+      $new[] = $item;
+    }
+    return $new;
   }
 
   /**

--- a/src/Y360Client.php
+++ b/src/Y360Client.php
@@ -110,7 +110,6 @@ class Y360Client {
     $queryParams = $this->buildWindowedQuery($fromTimestamp, $toTimestamp, $pageSize);
 
     $items = [];
-    $apiTotal = 0;
     $pagesFetched = 0;
 
     // The YMCA360 API always returns total_pages=0 regardless of the true
@@ -120,9 +119,6 @@ class Y360Client {
     do {
       $data = $this->doRequest($queryParams);
       $pagesFetched++;
-      if ($queryParams['page'] === 0) {
-        $apiTotal = $data['summary']['total_items'] ?? count($data['items'] ?? []);
-      }
 
       $pageItems = $data['items'] ?? [];
       if (empty($pageItems)) {
@@ -138,7 +134,7 @@ class Y360Client {
       'items' => $items,
       'stats' => [
         'pages_fetched' => $pagesFetched,
-        'api_total' => $apiTotal,
+        'api_total' => count($items),
         'window_items' => count($items),
       ],
     ];

--- a/src/Y360Client.php
+++ b/src/Y360Client.php
@@ -203,7 +203,7 @@ class Y360Client {
     $options = array_merge([
       'headers' => ['Accept' => 'application/json'],
       'auth' => $this->getAuth(),
-      'timeout' => 60,
+      'timeout' => 120,
     ], $options);
 
     $queryString = $this->buildQueryString($params);


### PR DESCRIPTION
## What

Builds on #14 (paginate by page exhaustion instead of `total_pages`) and adds two safety guards to `Y360Client::getSchedulesWindowed()`:

1. **Hard page ceiling** (`MAX_PAGES = 1000`) — page exhaustion stays the normal stop condition; this only trips if the API stops paginating correctly and the loop would otherwise run forever. Logs a warning when hit.
2. **No-progress guard** — tracks the occurrence ids already collected and stops if a page contributes none (the API repeating a page instead of advancing). As a side effect it de-duplicates the items that overlap a page boundary, so `api_total` reflects unique occurrences rather than the raw sum of page counts.

A small `collectNewItems()` helper does the id bookkeeping so the loop stays flat.

## Why

The exhaustion loop in #14 has no upper bound and relies on the API eventually returning a partial page. The API already returns `total_pages: 0` unconditionally (the bug #14 works around); if it regresses further and returns a stuck or repeating response, the loop has nothing to stop it. These guards make the fetch terminate safely in every case.

Adjacent pages can also repeat the boundary occurrence, so a blind `array_merge` over-counts the total slightly. De-duplicating by `id` corrects the reported totals.

## Notes

- Depends on #14. If #14 lands first, this PR's diff reduces to just the guard + helper. Happy to rebase, or this can supersede #14 — whichever you prefer, @froboy.

## Test

- Normal window: terminates by exhaustion, every page fetched, totals counted as unique occurrences.
- Confirmed against a live association feed: 16 pages fetched, raw page-sum vs unique-id count differed by the expected handful of boundary duplicates, all from adjacent-page overlap.
- No-progress and ceiling guards do not false-trigger on a healthy feed.
